### PR TITLE
Fix EscapeInstaller and MakeLuaInst .gitignores

### DIFF
--- a/ndless/src/tools/EscapeInstaller/.gitignore
+++ b/ndless/src/tools/EscapeInstaller/.gitignore
@@ -1,1 +1,1 @@
-EscapeInst* 
+EscapeInst*

--- a/ndless/src/tools/MakeLuaInst/.gitignore
+++ b/ndless/src/tools/MakeLuaInst/.gitignore
@@ -1,1 +1,1 @@
-MakeLuaInst* 
+MakeLuaInst*


### PR DESCRIPTION
Remove space at end of line.
Now "git status" doesn't report any changes after "make" in the base directory.
