### PR TITLE
To determine CHOST, use sed instead of head for portablity

### DIFF
--- a/ndless-sdk/thirdparty/Makefile
+++ b/ndless-sdk/thirdparty/Makefile
@@ -1,6 +1,6 @@
 GCC = nspire-gcc
 AR := "$(shell (which arm-elf-ar arm-none-eabi-ar arm-linux-gnueabi-ar | head -1) 2>/dev/null)"
-CHOST := $(shell (basename $(AR) | head -c -4))
+CHOST := $(shell (echo $(shell basename $(AR)) | sed 's/-ar$$//'))
 LIBDIR = ../lib
 INCDIR = ../include
 


### PR DESCRIPTION
I was relying on the behavior of GNU head, and that wouldn't have worked on Mac OS X or OpenBSD, at least. This should fix #44 by using sed instead. Somebody should test this before it is merged, because I don't have access to a Mac OS X system.