### PR TITLE
Fix Typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A guide for Developers can be found here:
 
 Pull requests and and issues are welcome!
 
-For more in-depth info, visit the wiki (on a different server for now):
+For more in-depth info, visit the wiki:
 
 ->    https://hackspire.org
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ Legal stuff
 ===========
 
 Most of the work is covered by the Mozilla Public License, version 1.1 (MPL). 
-Please read careful the file "Mozilla-Public-License-v1.1.html" before distributing of any part of Ndless, with or without modification.
+Please read carefully the file "Mozilla-Public-License-v1.1.html" before distributing any part of Ndless, with or without modification.
 
 Some parts are covered by other licenses. Others are in the public domain. These parts are identified by the files LICENSE.txt or LICENSE.html in the sub-directory.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ Legal stuff
 ===========
 
 Most of the work is covered by the Mozilla Public License, version 1.1 (MPL). 
-Please read carefully the file "Mozilla-Public-License-v1.1.html" before distributing any part of Ndless, with or without modification.
+Please read the file "Mozilla-Public-License-v1.1.html" carefully before distributing any part of Ndless, with or without modification.
 
 Some parts are covered by other licenses. Others are in the public domain. These parts are identified by the files LICENSE.txt or LICENSE.html in the sub-directory.


### PR DESCRIPTION
Fixed a typo in `Legal stuff`

> read careful **ly**

…

> before distributing **[…]** any part