### PR TITLE
Fix typo in hooks.h

### DIFF
--- a/ndless-sdk/include/hook.h
+++ b/ndless-sdk/include/hook.h
@@ -18,7 +18,7 @@
 	} while (0)
 
 /* Caution, hooks aren't re-entrant.
-* Must always exits with either HOOK_RESTORE_RETURN, HOOK_RETURN or HOOK_RESTORE_RETURN_SKIP.
+ * They must always exit with either HOOK_RESTORE_RETURN, HOOK_RETURN or HOOK_RESTORE_RETURN_SKIP.
  * A non-inlined body is required because naked function cannot use local variables.
  * A naked function is required because the return is handled by the hook, and to avoid any
  * register modification before they are saved */


### PR DESCRIPTION
**Disclaimer**: I haven't checked the rest of the file for typos. If you find any, feel free to suggest changes.

I'm not fully sure whether I understand this comment correctly and whether we need the `They`. However, `must always exit` stays the same no matter whether it's `it must exit` or `they must exit`.

Changed:
  * Fixed indention of block comment
  * Changed "Must exits" -> "They must exit"