### PR TITLE
Cache the path were ndless.cfg.tns was last found

### DIFF
--- a/ndless-sdk/libndls/config.c
+++ b/ndless-sdk/libndls/config.c
@@ -124,9 +124,12 @@ static int cfg_locate_cfg_file(char *dst_path, size_t dst_path_size) {
 }
 
 void cfg_open(void) {
-	char path[300];
-	if (cfg_locate_cfg_file(path, sizeof(path)))
-		return;
+	static char path[300] = "";
+	struct stat statbuf;
+	if (path[0] == '\0' || stat(path, &statbuf) != 0)
+		if (cfg_locate_cfg_file(path, sizeof(path)))
+			return;
+
 	cfg_open_file(path);
 }
 

--- a/ndless/src/resources/install.c
+++ b/ndless/src/resources/install.c
@@ -142,6 +142,10 @@ int main(int __attribute__((unused)) argc, char* argv[]) {
 			// The next HOOK_INSTALL invocation clears the cache for us
 		}
 
+		// Cache the path to ndless.cfg.tns to keep working even if the virtual root changes
+		cfg_open();
+		cfg_close();
+
 		if(ut_os_version_index < 6)
 			HOOK_INSTALL(ploader_hook_addrs[ut_os_version_index], plh_hook_31);
 		else if(ut_os_version_index < 26) // plh_hook_36 works for 3.9, 4.0 and 4.2 as well


### PR DESCRIPTION
Do it explicitly on startup so it can find the file even if the documents dir
changes.

Fixes #138

@pbfy0 This will conflict with your PR, which also caches the cfg path (but in a different function).

Binary for testing:
[ndless_resources.zip](https://github.com/ndless-nspire/Ndless/files/2441441/ndless_resources.zip)