### PR TITLE
Fix Dockerfiles

### DIFF
--- a/ndless-sdk/Dockerfile.arm-gcc
+++ b/ndless-sdk/Dockerfile.arm-gcc
@@ -6,7 +6,7 @@ FROM ndless/gcc
 RUN apt-get update
 
 # install the dependencies
-RUN apt-get install -y libgmp-dev libmpfr-dev libmpc-dev zlib1g-dev libtinfo-dev python2.7-dev libboost-program-options-dev
+RUN apt-get install -y libgmp-dev libmpfr-dev libmpc-dev zlib1g-dev libtinfo-dev python2.7-dev libboost-program-options-dev xz-utils
 
 RUN useradd -m -d /home/ndless -p ndless ndless && chsh -s /bin/bash ndless
 
@@ -16,5 +16,4 @@ ADD . /ndless-sdk
 RUN chown -R ndless:ndless /ndless-sdk && cd /ndless-sdk/toolchain && su ndless -c "./build_toolchain.sh && rm -rf download build-binutils build binutils-* gcc-* gdb-* newlib-* "
 
 ENV PATH /ndless-sdk/toolchain/install/bin:$PATH
-
 

--- a/ndless-sdk/Dockerfile.ndless-sdk
+++ b/ndless-sdk/Dockerfile.ndless-sdk
@@ -7,3 +7,6 @@ RUN chown -R ndless:ndless /ndless-sdk
 
 ENV PATH /ndless-sdk/bin:$PATH
 
+# (Re-)build the SDK
+RUN cd /ndless-sdk && make clean && make
+


### PR DESCRIPTION
This PR fixes Docker by adding the required `xz-utils` dependency and a call to `make` in the `/ndless-sdk` folder.

If this is merged, I request that the Docker images on Dockerhub are updated as well. This should fix #93.