### PR TITLE
Update gcc version in build_toolchain.sh

### DIFF
--- a/ndless-sdk/toolchain/build_toolchain.sh
+++ b/ndless-sdk/toolchain/build_toolchain.sh
@@ -16,10 +16,10 @@ TARGET=arm-none-eabi
 PREFIX="${PWD}/install" # or the directory where the toolchain should be installed in
 PARALLEL="${PARALLEL--j4}" # or "-j<number of build jobs>"
 
-BINUTILS=binutils-2.31.1 # http://www.gnu.org/software/binutils/
-GCC=gcc-8.2.0 # http://gcc.gnu.org/
-NEWLIB=newlib-3.0.0 # http://sourceware.org/newlib/
-GDB=gdb-8.1.1 # http://www.gnu.org/software/gdb/
+BINUTILS=binutils-2.32 # http://www.gnu.org/software/binutils/
+GCC=gcc-8.3.0 # http://gcc.gnu.org/
+NEWLIB=newlib-3.1.0 # http://sourceware.org/newlib/
+GDB=gdb-8.2.1 # http://www.gnu.org/software/gdb/
 
 # For newlib
 export CFLAGS_FOR_TARGET="-DHAVE_RENAME -DMALLOC_PROVIDED -DABORT_PROVIDED -DNO_FORK -mcpu=arm926ej-s -ffunction-sections -Ofast -funroll-loops"


### PR DESCRIPTION
I encountered this error (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724) using gcc 8.2.0 and had to manually add in the include statements in 'graphite.h' in order to successfully build the toolchain. Later versions of gcc fix this issue, so this error hopefully won't crop up again for other users. I also updated the versioning of the other dependencies, but feel free to reject this if it breaks backward compatibility somewhere.