### PR TITLE
Fix parsing of some syscall parameters

### DIFF
--- a/ndless-sdk/include/syscall-list.h
+++ b/ndless-sdk/include/syscall-list.h
@@ -48,7 +48,7 @@
 #define e_show_dialog_box2_ 30 // void show_dialog_box2_(int p1, const char *p2, const char *p3, const char **p4)
 #define e_strrchr 31
 #define e__vsprintf 32
-#define e_fseek 33 // int nuc_fseek(NUC_FILE *p1, long p2, int p3);
+#define e_fseek 33 // int nuc_fseek(NUC_FILE *p1, long p2, int p3)
 #define e_NU_Current_Dir 34 // int NU_Current_Dir(const char *p1, const char *p2)
 #define e_read_unaligned_longword 35
 #define e_read_unaligned_word 36
@@ -197,7 +197,7 @@
 #define e_lua_settable 179 // void lua_settable (lua_State *p1, int p2)
 #define e_lua_setfield 180 // void lua_setfield(lua_State *p1, int p2, const char *p3)
 #define e_lua_rawset 181 // void lua_rawset(lua_State *p1, int p2)
-#define e_lua_rawseti 182 // void lua_rawseti(lua_State *p1, int p2, int p3) 
+#define e_lua_rawseti 182 // void lua_rawseti(lua_State *p1, int p2, int p3)
 #define e_lua_setmetatable 183 // int lua_setmetatable(lua_State *p1, int p2)
 #define e_lua_setfenv 184 // int lua_setfenv(lua_State *p1, int p2)
 #define e_lua_call 185 // void lua_call(lua_State *p1, int p2, int p3)
@@ -332,7 +332,7 @@
 #define e_gui_gc_drawLine 314 // void gui_gc_drawLine(Gc p1, int p2, int p3, int p4, int p5)
 #define e_gui_gc_drawRect 315 // void gui_gc_drawRect(Gc p1, int p2, int p3, int p4, int p5)
 #define e_gui_gc_drawString 316 // void gui_gc_drawString(Gc p1, char *p2, int p3, int p4, gui_gc_StringMode p5)
-#define e_gui_gc_drawPoly 317 // void gui_gc_drawPoly(Gc p1, unsigned int* p2, unsigned int p3) 
+#define e_gui_gc_drawPoly 317 // void gui_gc_drawPoly(Gc p1, unsigned int* p2, unsigned int p3)
 #define e_gui_gc_fillArc 318 // void gui_gc_fillArc(Gc p1, int p2, int p3, int p4, int p5, int p6, int p7)
 #define e_gui_gc_fillPoly 319 // void gui_gc_fillPoly(Gc p1, unsigned int *p2, unsigned int p3)
 #define e_gui_gc_fillRect 320 // void gui_gc_fillRect(Gc p1, int p2, int p3, int p4, int p5)

--- a/ndless-sdk/libsyscalls/mkStubs.php
+++ b/ndless-sdk/libsyscalls/mkStubs.php
@@ -62,7 +62,7 @@ while(true)
 		break;
 
 	$matches = array();
-	$found = preg_match("%#define (e_.+) \\d+ // (([^ (]+)|\\((.+)\\)) (.+)\\((.*)\\)%", $lines[$i], $matches);
+	$found = preg_match("%^#define (e_.+) \\d+ // (([^ (]+)|\\((.+)\\)) (.+)\\((.*)\\)$%U", $lines[$i], $matches);
 	$i++;
 
 	/* Shouldn't be false if you didn't change anything */
@@ -87,7 +87,7 @@ while(true)
 		}*/
 
 	$rettype = $matches[3] == "" ? $matches[4] : $matches[3];
-	$param_count = $matches[6] == "" ? 0 : substr_count($matches[6], ",") + 1;
+	$param_count = $matches[6] == "" ? 0 : substr_count($matches[6], ", ") + 1;
 
 	if($param_count <= 4 && strpos($matches[6], "...") === FALSE)
 	{

--- a/ndless-sdk/libsyscalls/stubs.cpp
+++ b/ndless-sdk/libsyscalls/stubs.cpp
@@ -965,9 +965,27 @@ usb_endpoint_descriptor_t* usbd_get_endpoint_descriptor(usbd_interface_handle p1
 {
 	return syscall<e_usbd_get_endpoint_descriptor, usb_endpoint_descriptor_t*>(p1,p2);
 }
-int usb_register_driver(int p1, int(*p2[])(device_t), const char* p3, int p4, unsigned int p5)
+__attribute__((naked)) int usb_register_driver(int p1, int(*p2[])(device_t), const char* p3, int p4, unsigned int p5)
 {
-	return syscall<e_usb_register_driver, int>(p1,p2,p3,p4);
+	asm volatile("push {r4-r6}\n"
+				"ldr r4, =savedlr_stack\n"
+				"ldr r5, =savedlr_stack_nr\n"
+				"ldr r6, [r5]\n"
+				"add r6, r6, #1\n"
+				"str lr, [r4, r6, lsl #2]\n"
+				"str r6, [r5]\n"
+				"pop {r4-r6}\n"
+				"swi %[nr]\n"
+				"push {r4-r6}\n"
+				"ldr r4, =savedlr_stack\n"
+				"ldr r5, =savedlr_stack_nr\n"
+				"ldr r6, [r5]\n"
+				"ldr lr, [r4, r6, lsl #2]\n"
+				"sub r6, r6, #1\n"
+				"str r6, [r5]\n"
+				"pop {r4-r6}\n"
+				"bx lr\n"
+				".ltorg" :: [nr] "i" (e_usb_register_driver));
 }
 void* device_get_ivars(device_t p1)
 {
@@ -1037,7 +1055,7 @@ int16_t TI_NN_Write(nn_ch_t p1, void *p2, uint32_t p3)
 }
 int16_t TI_NN_StartService(uint32_t p1, void *p2, void(*p3)(nn_ch_t,void*))
 {
-	return syscall<e_TI_NN_StartService, int16_t>(p1,p2);
+	return syscall<e_TI_NN_StartService, int16_t>(p1,p2,p3);
 }
 int16_t TI_NN_StopService(uint32_t p1)
 {


### PR DESCRIPTION
- It didn't match parameters with parentheses in their declaration correctly,
  leading to the wrong number of arguments being parsed
- Made the regex nongreedy and match line start and end explicitly to fix this
- Fix syscall declarations with whitespace at the end

Fixes #193