### PR TITLE
Fix ndless_installer_4.5 on macOS

### DIFF
--- a/ndless/src/installer-4.5/Makefile
+++ b/ndless/src/installer-4.5/Makefile
@@ -4,6 +4,11 @@ AS := nspire-as
 LD := "$(shell (which arm-elf-ld arm-none-eabi-ld arm-linux-gnueabi-ld | head -1) 2>/dev/null)"
 OBJCOPY := "$(shell (which arm-elf-objcopy arm-none-eabi-objcopy arm-linux-gnueabi-objcopy | head -1) 2>/dev/null)"
 
+BASE64 := base64 -w0
+ifneq ($(shell base64 -w >/dev/null 2>&1; echo $$?),0)
+	BASE64 := base64
+endif
+
 GCCFLAGS := -Os -Wall -Wextra -nostdlib -fPIE -DSTAGE1 -D NDLESS_450
 GXXFLAGS := $(GCCFLAGS) -std=c++11 -fno-exceptions -fno-rtti
 LFLAGS := -nostdlib -Tldscript
@@ -27,7 +32,7 @@ all: $(DISTDIR)/ndless_installer_4.5.0.tns
 	$(OBJCOPY) -O binary $^ $@
 
 payload: ndless_installer.bin
-	(../tools/MakeChunkDispatch/MakeChunkDispatch 0x1800e7f4 0x12480000; cat $^) | base64 -w0 > $@ || rm $@
+	(../tools/MakeChunkDispatch/MakeChunkDispatch 0x1800e7f4 0x12480000; cat $^) | $(BASE64) > $@ || rm $@
 
 ndless_installer.elf: stage0.o stage1.o utils.o
 	$(LD) $(LFLAGS) $^ -o $@

--- a/ndless/src/installer-4.5/Makefile
+++ b/ndless/src/installer-4.5/Makefile
@@ -5,7 +5,7 @@ LD := "$(shell (which arm-elf-ld arm-none-eabi-ld arm-linux-gnueabi-ld | head -1
 OBJCOPY := "$(shell (which arm-elf-objcopy arm-none-eabi-objcopy arm-linux-gnueabi-objcopy | head -1) 2>/dev/null)"
 
 BASE64 := base64 -w0
-ifneq ($(shell base64 -w >/dev/null 2>&1; echo $$?),0)
+ifneq ($(shell base64 -w0 >/dev/null 2>&1 </dev/null; echo $$?),0)
 	BASE64 := base64
 endif
 


### PR DESCRIPTION
Mostly untested. Assumes the following have been installed with brew:

- binutils
- boost
- gcc
- git
- gmp
- libmpc
- mpfr
- wget
- zlib

May break if more than one gcc version is installed.