### PR TITLE
build_toolchain: update binutils, gcc, gdb

### DIFF
--- a/ndless-sdk/toolchain/build_toolchain.sh
+++ b/ndless-sdk/toolchain/build_toolchain.sh
@@ -16,10 +16,10 @@ TARGET=arm-none-eabi
 PREFIX="${PWD}/install" # or the directory where the toolchain should be installed in
 PARALLEL="${PARALLEL--j4}" # or "-j<number of build jobs>"
 
-BINUTILS=binutils-2.31.1 # http://www.gnu.org/software/binutils/
-GCC=gcc-8.2.0 # http://gcc.gnu.org/
+BINUTILS=binutils-2.34 # http://www.gnu.org/software/binutils/
+GCC=gcc-9.2.0 # http://gcc.gnu.org/
 NEWLIB=newlib-3.0.0 # http://sourceware.org/newlib/
-GDB=gdb-8.1.1 # http://www.gnu.org/software/gdb/
+GDB=gdb-9.1 # http://www.gnu.org/software/gdb/
 
 # For newlib
 export CFLAGS_FOR_TARGET="-DHAVE_RENAME -DMALLOC_PROVIDED -DABORT_PROVIDED -DNO_FORK -mcpu=arm926ej-s -ffunction-sections -Ofast -funroll-loops"


### PR DESCRIPTION
newlib may have broken ABI so let's not update that for now just in case.

This builds fine (well, better) on macOS than before because of some isl dependency issue ( https://github.com/kendryte/kendryte-gcc/commit/5b254d7c602ec112161daa0981e1b9ace1052c47 )