### PR TITLE
Fix cfg_register_fileext if ndless.cfg.tns doesn't exist yet

### DIFF
--- a/ndless-sdk/libndls/config.c
+++ b/ndless-sdk/libndls/config.c
@@ -172,6 +172,7 @@ void cfg_register_fileext_file(const char *filepath, const char *ext, const char
 // ext without leading '.'
 void cfg_register_fileext(const char *ext, const char *prgm) {
 	char path[300];
-	if (!cfg_locate_cfg_file(path, sizeof(path)))
-		cfg_register_fileext_file(path, ext, prgm);
+	if (cfg_locate_cfg_file(path, sizeof(path)))
+		snprintf(path, sizeof(path), "%s%s", get_documents_dir(), "ndless/ndless.cfg.tns");
+	cfg_register_fileext_file(path, ext, prgm);
 }


### PR DESCRIPTION
Got broken in #64 and might've caused the reports about nPDF not working properly.