### PR TITLE
build_toolchain.sh: Fix path in gcc configure options

### DIFF
--- a/ndless-sdk/toolchain/build_toolchain.sh
+++ b/ndless-sdk/toolchain/build_toolchain.sh
@@ -30,7 +30,7 @@ export CXXFLAGS_FOR_TARGET="-DHAVE_RENAME -DMALLOC_PROVIDED -DABORT_PROVIDED -DN
 export PATH="${PREFIX}/bin:${PATH}"
 
 OPTIONS_BINUTILS="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --with-system-zlib --with-gnu-as --with-gnu-ld --disable-nls --with-float=soft --disable-werror"
-OPTIONS_GCC="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --enable-languages="c,c++" --with-system-zlib --with-newlib --with-headers=../${NEWLIB}/newlib/libc/include --disable-threads --disable-tls --disable-shared --with-gnu-as --with-gnu-ld --with-float=soft --disable-werror --disable-libstdcxx-verbose"
+OPTIONS_GCC="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --enable-languages="c,c++" --with-system-zlib --with-newlib --with-headers=../download/${NEWLIB}/newlib/libc/include --disable-threads --disable-tls --disable-shared --with-gnu-as --with-gnu-ld --with-float=soft --disable-werror --disable-libstdcxx-verbose"
 OPTIONS_NEWLIB="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --with-gnu-as --with-gnu-ld --disable-newlib-may-supply-syscalls --disable-newlib-supplied-syscalls --with-float=soft --disable-werror --disable-nls --enable-newlib-io-float"
 OPTIONS_GDB="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --disable-werror"
 


### PR DESCRIPTION
This caused a different set of headers to be used.

AFAICT this isn't actually quite how it's meant to work, as this copies over the non-arch specific headers to a path with higher priority. It would require upgrading newlib with a version that doesn't have an incomplete `param.h` for arm or deleting that file manually, but the hack to delete `sys-include/newlib.h` would not be needed anymore.

For now let's just keep the status quo to avoid more surprises.

Fixes #216