### PR TITLE
Put _toolchainpath in PATH in nspire-* scripts

### DIFF
--- a/ndless-sdk/bin/arm-none-eabi-ld.gold
+++ b/ndless-sdk/bin/arm-none-eabi-ld.gold
@@ -33,6 +33,6 @@ MAKEFLAGS='' make -C "$NDLESS/system" -s all
 home="${USERPROFILE:-$HOME}"
 mkdir -p "$home/.ndless/lib"
 
-LD="$(nspire-tools _toolchainpath)/arm-none-eabi-ld"
+export PATH="$(nspire-tools _toolchainpath):$PATH"
 
-exec "$LD" --pic-veneer --emit-relocs -T "${NDLESS}/system/ldscript" -static "${NDLESS}/system/crt0.o" "${NDLESS}/system/crti.o" "${args[@]}" "${stdlib[@]}" "${NDLESS}/system/crtn.o" -L "${NDLESS}/lib" -L "${home}/.ndless/lib"
+exec arm-none-eabi-ld --pic-veneer --emit-relocs -T "${NDLESS}/system/ldscript" -static "${NDLESS}/system/crt0.o" "${NDLESS}/system/crti.o" "${args[@]}" "${stdlib[@]}" "${NDLESS}/system/crtn.o" -L "${NDLESS}/lib" -L "${home}/.ndless/lib"

--- a/ndless-sdk/bin/nspire-as
+++ b/ndless-sdk/bin/nspire-as
@@ -4,5 +4,5 @@
 NDLESS="$(nspire-tools path)"
 
 # gcc instead of as, to call the C preprocessor
-GCC="$(nspire-tools _toolchainpath)/arm-none-eabi-gcc"
-exec "$GCC" -mcpu=arm926ej-s -D GNU_AS "$@" -I "$NDLESS/include"
+export PATH="$(nspire-tools _toolchainpath):$PATH"
+exec arm-none-eabi-gcc -mcpu=arm926ej-s -D GNU_AS "$@" -I "$NDLESS/include"

--- a/ndless-sdk/bin/nspire-g++
+++ b/ndless-sdk/bin/nspire-g++
@@ -2,8 +2,8 @@
 # Caution, must be kept compatible with dash used by some Linux distros.
 
 NDLESS="$(nspire-tools path)"
+export PATH="$(nspire-tools _toolchainpath):$PATH"
 
 home="${USERPROFILE:-$HOME}"
 mkdir -p "$home/.ndless/include"
-GXX="$(nspire-tools _toolchainpath)/arm-none-eabi-g++"
-exec "$GXX" -mcpu=arm926ej-s -fno-use-cxa-atexit -D _TINSPIRE -fuse-ld=gold "$@" -I "$home/.ndless/include" -I "${NDLESS}/include" -I "${NDLESS}/include/freetype2"
+exec arm-none-eabi-g++ -mcpu=arm926ej-s -fno-use-cxa-atexit -D _TINSPIRE -fuse-ld=gold "$@" -I "$home/.ndless/include" -I "${NDLESS}/include" -I "${NDLESS}/include/freetype2"

--- a/ndless-sdk/bin/nspire-gcc
+++ b/ndless-sdk/bin/nspire-gcc
@@ -2,8 +2,8 @@
 # Caution, must be kept compatible with dash used by some Linux distros.
 
 NDLESS="$(nspire-tools path)"
+export PATH="$(nspire-tools _toolchainpath):$PATH"
 
 home="${USERPROFILE:-$HOME}"
 mkdir -p "$home/.ndless/include"
-GCC="$(nspire-tools _toolchainpath)/arm-none-eabi-gcc"
-exec "$GCC" -mcpu=arm926ej-s -D _TINSPIRE -fuse-ld=gold "$@" -I "$home/.ndless/include" -I "${NDLESS}/include" -I "${NDLESS}/include/freetype2"
+exec arm-none-eabi-gcc -mcpu=arm926ej-s -D _TINSPIRE -fuse-ld=gold "$@" -I "$home/.ndless/include" -I "${NDLESS}/include" -I "${NDLESS}/include/freetype2"


### PR DESCRIPTION
This allows to not link every single `arm-none-eabi-*` executable into usr/bin in my AUR package, which will reduce conflicts with e.g. arm-none-eabi-binutils