### PR TITLE
Switch to using cxa_atexit for static destruction

### DIFF
--- a/ndless-sdk/bin/nspire-g++
+++ b/ndless-sdk/bin/nspire-g++
@@ -6,4 +6,4 @@ export PATH="$(nspire-tools _toolchainpath):$PATH"
 
 home="${USERPROFILE:-$HOME}"
 mkdir -p "$home/.ndless/include"
-exec arm-none-eabi-g++ -mcpu=arm926ej-s -fno-use-cxa-atexit -D _TINSPIRE -fuse-ld=gold "$@" -I "$home/.ndless/include" -I "${NDLESS}/include" -I "${NDLESS}/include/freetype2"
+exec arm-none-eabi-g++ -mcpu=arm926ej-s -D _TINSPIRE -fuse-ld=gold "$@" -I "$home/.ndless/include" -I "${NDLESS}/include" -I "${NDLESS}/include/freetype2"


### PR DESCRIPTION
Using the atexit mechanism for static object destruction is the only way to
ensure that it's correctly ordered as required by the standard. This way
they also run when calling exit instead of returning from main.