### PR TITLE
Only perform cleanup when exiting cleanly

### DIFF
--- a/ndless-sdk/include/nucleus.h
+++ b/ndless-sdk/include/nucleus.h
@@ -124,6 +124,9 @@ unsigned int nl_hwsubtype();
 BOOL nl_loaded_by_3rd_party_loader();
 BOOL nl_isstartup();
 BOOL _nl_hassyscall(int nr);
+// Mark the program as resident, i.e. don't unload the executable on exit.
+// Instead of calling exit or return from main, _exit has to be used.
+// Otherwise cleanup breaks some library functions!
 void nl_set_resident();
 unsigned int nl_osvalue(const unsigned int *values, unsigned size);
 int nl_exec(const char* prg, int argc, char** argv);

--- a/ndless-sdk/samples/luaext/luaextdemo.c
+++ b/ndless-sdk/samples/luaext/luaextdemo.c
@@ -17,5 +17,7 @@ int main(void) {
 	lua_State *L = nl_lua_getstate();
 	if (!L) return 0; // not being called as Lua module
 	luaL_register(L, "luaextdemo", lualib);
-	return 0;
+
+	// Skip cleanup on exit, this is a resident program
+	_exit(0);
 }


### PR DESCRIPTION
In some circumstances, it's important to skip cleanup on exit, like in the case
of crash handlers and especially for resident programs.

Make luaextdemo use that feature.

See #287