### PR TITLE
Compile with all cores and upload the Build Artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,3 +50,8 @@ jobs:
         run: sudo apt install -y libboost-program-options-dev
       - name: Build
         run: make -j$(nproc --all)
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: output
+          path: ndless/calcbin/*.tns

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Install dependencies
         run: sudo apt install -y libboost-program-options-dev
       - name: Build
-        run: make -j4
+        run: make -j$(nproc --all)


### PR DESCRIPTION
Compile with all cores to speed it up and adjust it to the host
Upload the Build Artifacts so they can be testet easier