### PR TITLE
Various zehn_loader improvements

### DIFF
--- a/ndless-sdk/tools/zehn_loader/Makefile
+++ b/ndless-sdk/tools/zehn_loader/Makefile
@@ -7,11 +7,11 @@ ZLIB_CFLAGS := -Os -fPIE -ffunction-sections -fdata-sections -DNO_GZIP -ffreesta
 
 all: zehn_loader.tns zehn_loader_compressed.tns
 
-zehn_loader_compressed.tns.elf: loader.cpp zlib/libz.a
-	$(GXX) $(GXXFLAGS) $^ -o $@ -DENABLE_ZLIB -lgcc
+zehn_loader_compressed.tns.elf: ldscript loader.cpp zlib/libz.a
+	$(GXX) $(GXXFLAGS) loader.cpp zlib/libz.a -o $@ -DENABLE_ZLIB -lgcc
 
-zehn_loader.tns.elf: loader.cpp
-	$(GXX) $(GXXFLAGS) $^ -o $@
+zehn_loader.tns.elf: ldscript loader.cpp
+	$(GXX) $(GXXFLAGS) loader.cpp -o $@
 
 zehn_loade%.tns: zehn_loade%.tns.elf
 	$(OBJCOPY) --set-section-flags .pad=alloc,load,contents -O binary $^ $@

--- a/ndless-sdk/tools/zehn_loader/Makefile
+++ b/ndless-sdk/tools/zehn_loader/Makefile
@@ -14,7 +14,7 @@ zehn_loader.tns.elf: loader.cpp
 	$(GXX) $(GXXFLAGS) $^ -o $@
 
 zehn_loade%.tns: zehn_loade%.tns.elf
-	$(OBJCOPY) -O binary $^ $@
+	$(OBJCOPY) --set-section-flags .pad=alloc,load,contents -O binary $^ $@
 
 zlib/Makefile: ../../thirdparty/zlib/configure
 	mkdir -p zlib

--- a/ndless-sdk/tools/zehn_loader/ldscript
+++ b/ndless-sdk/tools/zehn_loader/ldscript
@@ -11,7 +11,6 @@ SECTIONS
 		*(.got.plt);
 		*(.got);
 	}
-	/* .bss before .data, to make sure space is allocated for it in the binary file */
 	.bss : {
 		*(.bss);
 		*(.bss.*);
@@ -20,7 +19,10 @@ SECTIONS
 		*(.data);
 		*(.data.*);
 	}
-
-	. = ALIGN(4);
+	/* Put padding into its own section which is force included
+	   by the objcopy call. This ensures that NOBITS data is filled. */
+	.pad : {
+		. = ALIGN(4);
+	}
 }
 zehn_start = .;

--- a/ndless-sdk/tools/zehn_loader/loader.cpp
+++ b/ndless-sdk/tools/zehn_loader/loader.cpp
@@ -72,9 +72,9 @@ int main(int argc, char **argv)
 
 		old_storage = reinterpret_cast<const uint8_t*>(header);
 		syscall<e_memcpy, void*>(mallocd, old_storage, header->file_size);
-		header = reinterpret_cast<const Zehn_header*>(mallocd);
+		header = reinterpret_cast<const Zehn_header*>(__builtin_assume_aligned(mallocd, 4));
 	}
-	
+
 	const Zehn_reloc *reloc_table = reinterpret_cast<const Zehn_reloc*>(reinterpret_cast<const uint8_t*>(header) + sizeof(Zehn_header));
 	//This loader doesn't parse the flag table
 	const uint8_t *flag_table = reinterpret_cast<const uint8_t*>(reloc_table) + sizeof(Zehn_reloc) * header->reloc_count;


### PR DESCRIPTION
* zehn_loader: Make sure padding ends up in the raw binary
* zehn_loader: Include ldscript as dependency
* zehn_loader: Tell the compiler that the malloced header is aligned

Fixes #418