### PR TITLE
Toolchain update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build
         run: make -j$(nproc --all)
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output-${{ matrix.os }}
           path: ndless/calcbin/*.tns

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: output
+          name: output-${{ matrix.os }}
           path: ndless/calcbin/*.tns

--- a/ndless-sdk/libsyscalls/stdlib.cpp
+++ b/ndless-sdk/libsyscalls/stdlib.cpp
@@ -558,6 +558,12 @@ clock_t _times(struct tms *ptms)
 	return 0;
 }
 
+int _getentropy (void *, size_t)
+{
+	errno = ENOSYS;
+	return -1;
+}
+
 // Miscellaneous
 void *__dso_handle __attribute__((weak));
 void __sync_synchronize(){}

--- a/ndless-sdk/samples/zehn/test.cpp
+++ b/ndless-sdk/samples/zehn/test.cpp
@@ -4,17 +4,27 @@
 
 using namespace std;
 
+// Test global object construcion and order.
+// This should work both with -fuse-cxa-atexit (the default)
+// and -fno-use-cxa-atexit.
+template <int i>
 class Test
 {
 public:
-	Test() { cout << "Test();" << endl; }
-	~Test() { cout << "~Test();" << endl; }
+	Test() { cout << "Test(" << i << ")" << endl; }
+	~Test() {
+		cout << "~Test(" << i << ")" << endl;
+		if (i == 1000) // Should be last
+			wait_key_pressed();
+	}
 
 	void doSomething() { cout << "Doing something!" << endl; }
 };
 
-//Test global variables + initialization
-static Test test;
+static __attribute__ ((init_priority (1000))) Test<1000> t1000;
+static __attribute__ ((init_priority (1001))) Test<1001> t1001;
+// No init_priority is means higher than any init_priority
+static Test<1024> test;
 
 int main()
 {

--- a/ndless-sdk/system/crti.S
+++ b/ndless-sdk/system/crti.S
@@ -2,7 +2,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 /* For C++ support */
 
-.section .init_array
+.section .init_array.0
 __cpp_init: .global __cpp_init
 	push {r0, r1, r4, r5, lr}
 	adr r4,ctors

--- a/ndless-sdk/system/crtn.S
+++ b/ndless-sdk/system/crtn.S
@@ -9,5 +9,5 @@ exit: .weak exit /* If linked without newlib, used by crt0. Can't be defined in 
 .section .init_array
 	.long -1 /* Terminating character for ctor list */
     
-.section .fini_array
+.section .fini_array.0
 	.long -1

--- a/ndless-sdk/system/ldscript
+++ b/ndless-sdk/system/ldscript
@@ -5,8 +5,10 @@ SECTIONS {
 		_start = .;
 		*(.text)
 		KEEP(*(.text.crtn))
+		KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*)))
 		KEEP(*(.init_array))
 		KEEP(*(.fini_array))
+		KEEP(*(SORT_BY_INIT_PRIORITY(REVERSE(.fini_array.*))))
 		*(.text.*)
 	}
 

--- a/ndless-sdk/toolchain/build_toolchain.sh
+++ b/ndless-sdk/toolchain/build_toolchain.sh
@@ -19,19 +19,19 @@ PREFIX="${PWD}/install" # or the directory where the toolchain should be install
 PARALLEL="${PARALLEL--j4}" # or "-j<number of build jobs>"
 PYTHON="${PYTHON-$(which python3 2>/dev/null)}" # or the full path to the python interpreter
 
-BINUTILS=binutils-2.38 # https://www.gnu.org/software/binutils/
-GCC=gcc-11.2.0 # https://gcc.gnu.org/
-NEWLIB=newlib-4.1.0 # https://sourceware.org/newlib/
-GDB=gdb-11.2 # https://www.gnu.org/software/gdb/
+BINUTILS=binutils-2.44 # https://www.gnu.org/software/binutils/
+GCC=gcc-14.2.0 # https://gcc.gnu.org/
+NEWLIB=newlib-4.5.0.20241231 # https://sourceware.org/newlib/
+GDB=gdb-16.2 # https://www.gnu.org/software/gdb/
 
 # For newlib
 export CFLAGS_FOR_TARGET="-DHAVE_RENAME -DMALLOC_PROVIDED -DABORT_PROVIDED -DNO_FORK -mcpu=arm926ej-s -ffunction-sections -O3"
 export CXXFLAGS_FOR_TARGET="-DHAVE_RENAME -DMALLOC_PROVIDED -DABORT_PROVIDED -DNO_FORK -mcpu=arm926ej-s -ffunction-sections -O3"
 export PATH="${PREFIX}/bin:${PATH}"
 
-OPTIONS_BINUTILS="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --with-system-zlib --with-gnu-as --with-gnu-ld --disable-nls --with-float=soft --disable-werror"
+OPTIONS_BINUTILS="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --with-system-zlib --with-gnu-as --with-gnu-ld --disable-nls --with-float=soft --disable-werror --enable-warn-rwx-segments=no"
 OPTIONS_GCC="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --enable-languages=c,c++ --with-system-zlib --with-newlib --disable-threads --disable-tls --disable-shared --with-gnu-as --with-gnu-ld --with-float=soft --disable-werror --disable-libstdcxx-verbose"
-OPTIONS_NEWLIB="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --with-gnu-as --with-gnu-ld --enable-newlib-io-long-long --disable-newlib-may-supply-syscalls --disable-newlib-supplied-syscalls --with-float=soft --disable-werror --disable-nls --enable-newlib-io-float"
+OPTIONS_NEWLIB="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --with-gnu-as --with-gnu-ld --enable-newlib-io-long-long --disable-newlib-may-supply-syscalls --disable-newlib-supplied-syscalls --with-float=soft --disable-werror --disable-nls --enable-newlib-io-float --enable-newlib-reent-binary-compat"
 OPTIONS_GDB="--target=${TARGET} --prefix=${PREFIX} --enable-interwork --enable-multilib --disable-werror"
 
 if [ -n "${PYTHON}" ]; then


### PR DESCRIPTION
- binutils 2.44
- GCC 14.2.0
- newlib 4.5.0
- GDB 16.2

Might need nSDL rebuilt, could also drop `--enable-newlib-reent-binary-compat` then.

For some reason, the `newlib-c++` sample pulls in arc4random which requires `_getentropy` and is massive. Needs investigation why.