### PR TITLE
ut_calc_reboot fix

### DIFF
--- a/ndless/src/resources/utils.c
+++ b/ndless/src/resources/utils.c
@@ -37,6 +37,10 @@ unsigned int ut_os_version_index;
 
 void __attribute__ ((noreturn)) ut_calc_reboot(void) {
 	*(volatile unsigned*)0x900A0008 = 2; //CPU reset
+	
+	asm ("bkpt"); 	// Temporary solution as 0x900A0008 doesn't work on the CX II - bkpt will crash anything anyways
+			// TODO: Watchdog
+	
 	__builtin_unreachable();
 }
 


### PR DESCRIPTION
Temporary fix for Ndless uninstalling. Works on 5.3.0.564 - should use watchdog code instead of this