### PR TITLE
CX II LCD fixes + Luna update 

### DIFF
--- a/ndless/src/resources/install.c
+++ b/ndless/src/resources/install.c
@@ -145,6 +145,10 @@ int main(int __attribute__((unused)) argc, char* argv[]) {
 		// Load is_hww
 		lcd_compat_load_hwrev();
 
+		// Patch leftmost column on the CX II being cut off
+		if (nl_is_cx2() && *(volatile unsigned int*)0xC0000004 == 0x03780d3f)
+			*(volatile unsigned int *)0xC0000004 = 0x0720013F;
+
 		// 3.9, 4.0.3 and 4.2.0 don't need to be rebooted
 		if(ut_os_version_index < 10)
 		{

--- a/ndless/src/resources/ploaderhook.c
+++ b/ndless/src/resources/ploaderhook.c
@@ -371,14 +371,6 @@ int ld_exec_with_args(const char *path, int argsn, char *args[], void **resident
 		memcpy(argvptr, args, argsn * sizeof(char*));
 
 	argv[argc] = NULL;
-
-	volatile uint32_t *cursorctrl = (volatile uint32_t*)0xC0000C00;
-	uint32_t saved_cursorctrl = 0;
-	if(is_cx2) {
-		// Disable the LCDC cursor overlay
-		saved_cursorctrl = *cursorctrl;
-		*cursorctrl &= ~1;
-	}
 	
 	if (has_colors) {
 		volatile unsigned *palette = (volatile unsigned*)0xC0000200;
@@ -387,8 +379,16 @@ int ld_exec_with_args(const char *path, int argsn, char *args[], void **resident
 		ut_disable_watchdog(); // seems to be sometimes renabled by the OS
 	}
 
-        if(!supports_hww)
+	if(!supports_hww)
 		lcd_compat_enable();
+
+	volatile uint32_t *cursorctrl = (volatile uint32_t*)0xC0000C00;
+	uint32_t saved_cursorctrl = 0;
+	if(is_cx2) {
+		// Disable the LCDC cursor overlay
+		saved_cursorctrl = *cursorctrl;
+		*cursorctrl &= ~1;
+	}
 	
 	clear_cache();
 	ret = entry(argc, argv); /* run the program */


### PR DESCRIPTION
* Fix that the cursor was sometimes visible in lcd_compat mode
* Fix for an OS bug that hid the leftmost LCD column on CX II
* Update Luna
* Use the watchdog as fallback reset method to make `ut_calc_reboot` work on CX II

Contributions from @satyamedh