### PR TITLE
Add error messages to installer 6.2 and move installed text to the bottom of the screen

### DIFF
--- a/ndless/src/installer-6.2/ipc.lua
+++ b/ndless/src/installer-6.2/ipc.lua
@@ -1,42 +1,26 @@
 do
-    local ipc_messages = {"install_start", "install_start3", "install_start4", "install_done", "install_failed", "install_kaput"}
-    local ipc_counter  = 0
-    local ipc_name     = "ipc" .. math.floor(math.random() * 10000)
+    local ipc_subscriptions = {}
 
-    function ipc_load()        
-        for i,msg in ipairs(ipc_messages) do
-            ipc_messages[msg] = i
-            print("Registering IPC msg:", ipc_name, msg)
-            var.monitor(msg)
-        end
+    function ipc_subscribe(msg, callback)
+        clipboard.addText("empty")        
+        ipc_subscriptions[msg] = callback
     end
 
-    function ipc_send(msg)
-        local m = nil
-        local t = type(msg)
-
-        if t == "string" and ipc_messages[msg] then
-            m = msg
-        elseif t == "number" then
-            m = ipc_messages[msg]
-        end
-
-
-        if m then
-            print("store", m, ipc_name .. ipc_counter)
-            var.store(m, ipc_name .. ipc_counter)
-        end
+    function ipc_send(...)
+        ipc_tick()
+        clipboard.addText(table.concat({...},":"))
     end
 
-    function on.varChange(t)
-        print("varchange", ipc_name, table.concat(t, ","))
-        for k,msg in pairs(t) do 
-            print(k,msg)
-            if type(on.ipcMsg) == "function" then
-                on.ipcMsg(msg, ipc_counter)
-            end
+    function ipc_tick()
+        local m = clipboard.getText()
+
+        if not m then return end
+        local msg = m:split(":")
+
+        local s = ipc_subscriptions[msg[1]]
+        if type(s) == "function" then
+            s(unpack(msg))
+            clipboard.addText("empty")
         end
-        ipc_counter = ipc_counter + 1
-        return -2
     end
 end

--- a/ndless/src/installer-6.2/stage0.S
+++ b/ndless/src/installer-6.2/stage0.S
@@ -5,6 +5,10 @@ _start: .global _start
 push {r4-r12, lr}
 sub	sp, sp, #0x40
 
+@ status = 1
+mov r0, #1
+str r0, result
+
 @ r10 = pointer to osdata struct
 adr	r10, osdata
 mov	r0, #0x10000000
@@ -20,6 +24,10 @@ add	r10, r10, #(nextos-osdata)
 b osloop
 
 osfound: @ r10 points to the right OS now
+
+@ status = 2 
+mov r0, #2
+str r0, result
 
 adr	r0, respath
 mov	r1, sp
@@ -40,6 +48,11 @@ mov	lr, pc
 ldr	pc, [r10, #(os_fopen-osdata)] @ call fopen
 movs	r6, r0 @ r6 = FILE*
 beq	return
+
+@ status = 3
+mov r0, #3
+str r0, result
+
 mov	r0, r5
 mov	r1, r4
 mov	r2, #1
@@ -120,3 +133,10 @@ respath:
 
 oflags:
 .asciz "rb"
+
+@ result variable is periodically read by the installer through a hardcoded offset.
+@ will be used to determine the success
+
+.align 2
+result:
+.word 0x0

--- a/ndless/src/resources/install.c
+++ b/ndless/src/resources/install.c
@@ -270,6 +270,8 @@ void ins_install_successmsg_hook(void) {
 
 // chained after the startup programs execution
 HOOK_DEFINE(ins_successsuccessmsg_hook) {
+	unsigned short msg[] = u"Ndless successfully installed!";
+
 	static bool closed = false;
 	if (!closed && close_document_addrs[ut_os_version_index] && !ins_loaded_by_3rd_party_loader()) {
 		// To not close more than necessary and prevent recursion
@@ -281,8 +283,10 @@ HOOK_DEFINE(ins_successsuccessmsg_hook) {
 	if (HOOK_SAVED_REGS(ins_successsuccessmsg_hook)[2] == ins_successmsg_icon[ut_os_version_index]) {
 		Gc gc = (Gc)HOOK_SAVED_REGS(ins_successsuccessmsg_hook)[0];
 		gui_gc_setColor(gc, has_colors ? 0x32cd32 : 0x505050);
-		gui_gc_setFont(gc, SerifRegular9);
-		gui_gc_drawString(gc, (char*) u"Ndless installed!", 25, 4, GC_SM_TOP);
+		gui_gc_setFont(gc, Bold9);
+		
+		int str_width = gui_gc_getStringWidth(gc, Bold9, (char*)msg, 0, 0xFFFFFFFF);
+		gui_gc_drawString(gc, (char*)msg, (320 - str_width) / 2, 212, GC_SM_TOP);
 
 		static int i = 6;
 		if (!i--) {

--- a/ndless/src/tools/LuaBin/luabin.cpp
+++ b/ndless/src/tools/LuaBin/luabin.cpp
@@ -19,8 +19,8 @@ std::string luaForOS(std::string installer_filename, std::string varname)
 
 	buffer_content.insert(buffer_content.end(), std::istreambuf_iterator<char>{installer_bin}, std::istreambuf_iterator<char>{});
 
-	//4-byte alignment
-	buffer_content.resize((buffer_content.size() + 4) & ~3);
+	//Do 4-byte alignment if not already aligned
+	buffer_content.resize((buffer_content.size() + 3) & ~3);
 
 	std::cerr << "Size of buffer: 0x" << std::hex << buffer_content.size() << std::endl;
 

--- a/ndless/src/tools/MakeSyscalls/idc/OS_cascx-4.5.5.79.idc
+++ b/ndless/src/tools/MakeSyscalls/idc/OS_cascx-4.5.5.79.idc
@@ -859,7 +859,7 @@ static main(void)
 	MakeName	(0x10a7c4bc,    "lua_math__evalexpr");
 	MakeName	(0x10a9de8c,    "cpSpace_addCollisionHandler");
 	MakeName	(0x10aa09f8,    "cpSpace_step");
-	MakeName	(0x1183b0d8,	"keypad_type");
+	MakeName	(0x112f5e2c,	"keypad_type");
     MakeName	(0x113b0f28,	"gui_gc_global_GC_ptr");
     MakeName	(0x114a3afc,	"stdin");
     MakeName	(0x114a3b48,	"stdout");


### PR DESCRIPTION
Courtesy entirely of @jimbauwens - I just squashed his commits

Moves the "Ndless installed!" text to the bottom of the screen, bold and centered, such that it doesnt hit the CAS/Exact Arithmetic text on some calculators.

Also adds error messages to the Lua installer, specifically for wrong OS version and missing resources.

Testing on Firebird revealed no issues.