### PR TITLE
ndless: Use absolute path on stage0

### DIFF
--- a/ndless/src/installer-6.2/stage0.S
+++ b/ndless/src/installer-6.2/stage0.S
@@ -150,8 +150,9 @@ endos:
 .word 0x0
 
 respath:
-.asciz "ndless/ndless_resources.tns"
+.asciz "A:\\documents\\ndless\\ndless_resources.tns"
 
+.align 2
 oflags:
 .asciz "rb"
 

--- a/ndless/src/persistent-6.4/stage0.S
+++ b/ndless/src/persistent-6.4/stage0.S
@@ -148,8 +148,9 @@ argv_0:
 .asciz "PER" @ for alignment, only P is checked for
 
 respath:
-.asciz "ndless/ndless_resources.tns"
+.asciz "A:\\documents\\ndless\\ndless_resources.tns"
 
+.align 2
 oflags:
 .asciz "rb"
 


### PR DESCRIPTION
Jim discovered that the installer's stage0 can fail with a missing resources error in the case that the user does something to `chdir,` like opening the scratchpad.

By doing this it will use an absolute path avoiding the need for a relative path.

However, this does break a tradition where Ndless would `chdir` to the documents directory via `get_documents_dir()`. In my own opinion that doesn't matter as much since the Lua exploit is disabled in PTT mode, i.e. the only place where the path would actually differ.